### PR TITLE
cleanup: remove unused cameraIcon export

### DIFF
--- a/src/component/icons.ts
+++ b/src/component/icons.ts
@@ -19,11 +19,4 @@ export const uploadIcon = svg`
   </svg>
 `;
 
-/** Camera icon for mobile capture. */
-export const cameraIcon = svg`
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-       stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px">
-    <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/>
-    <circle cx="12" cy="13" r="3"/>
-  </svg>
-`;
+


### PR DESCRIPTION
hey, saw the issue about cleaning up unused exports. the cameraIcon in icons.ts was exported but never used anywhere, so i removed it.

tests still pass and build works fine. let me know if you need anything else!